### PR TITLE
fix: preserve catalog data in Vercel builds

### DIFF
--- a/site/scripts/build-data.mjs
+++ b/site/scripts/build-data.mjs
@@ -16,6 +16,17 @@ if (process.env.SKIP_DATA_BUILD === '1') {
 // Directories containing idea files
 const IDEA_DIRS = ['ideas', 'pr', 'prs', 'proposals', 'pr-proposals', 'features', 'fix'];
 
+const hasRepositorySources = IDEA_DIRS.some((dir) => fs.existsSync(path.join(ROOT, dir)));
+if (!hasRepositorySources) {
+  const hasGeneratedData = fs.existsSync(path.join(OUT, 'ideas.json'))
+    && fs.existsSync(path.join(OUT, 'content-map.json'));
+  if (!hasGeneratedData) {
+    throw new Error(`Idea source directories are unavailable under ${ROOT}, and no generated data was committed`);
+  }
+  console.log(`Idea sources are unavailable under ${ROOT}; using committed generated data`);
+  process.exit(0);
+}
+
 // Meta files to skip
 const SKIP_FILES = new Set([
   'README.md', 'README_EN.md', 'TEMPLATE.md', 'INTERACTIVE_TEMPLATE.md',

--- a/site/scripts/build-data.mjs
+++ b/site/scripts/build-data.mjs
@@ -288,7 +288,6 @@ function buildData() {
   });
 
   const output = {
-    generatedAt: new Date().toISOString(),
     totalIdeas: ideas.length,
     scoredIdeas: ideas.filter(i => i.overall != null).length,
     tier1: ideas.filter(i => i.tier === 1).map(withoutContent),

--- a/site/src/data/ideas.json
+++ b/site/src/data/ideas.json
@@ -1,5 +1,4 @@
 {
-  "generatedAt": "2026-07-11T14:24:54.347Z",
   "totalIdeas": 155,
   "scoredIdeas": 0,
   "tier1": [],


### PR DESCRIPTION
## Summary
- keep committed catalog data when Vercel builds only the `site/` root
- continue mandatory source regeneration when the full repository is available
- remove the unused wall-clock timestamp so generation is deterministic

## Verification
- full-repository generation: 155 ideas
- isolated site-only generation: committed data preserved
- two consecutive generations produce identical SHA-256 hashes
- lint, type-check, test, and 161-page build pass